### PR TITLE
Fix the early exit tolerance check

### DIFF
--- a/EasyIK/Assets/Scripts/EasyIK.cs
+++ b/EasyIK/Assets/Scripts/EasyIK.cs
@@ -174,6 +174,7 @@ public class EasyIK : MonoBehaviour
                 {
                     break;
                 }
+                distToTarget = Vector3.Distance(jointPositions[jointPositions.Length - 1], ikTarget.position);
             }
         }
         // Apply the pole constraint


### PR DESCRIPTION
Hey there, 

While benchmarking a bunch of solutions for procedural animation, I noticed a small performance issue that this aims to fix.

The distance between the final bone and the target was not recomputed after checking if we performed enough iterations, which means we either never went through the loop (when the target position was previously reached and didn't move too much), or always performed the full iteration count, which might be a performance concern with high iteration count or if there is many instances of the script running.

Please note that the default tolerance value might be a bit high, it is easier to notice with this change and might make the movement appear stuttery (when in fact the target point probably didn't move enough). This could be improved by forcing at least 1 iteration to be performed, but that's an implementation choice.

Thanks for putting this piece of code out there, made me win a bit of time while exploring procedural animation options

Sylvain