### PR TITLE
Update mode selection, update solver in editor, assign joints manually, bug fix

### DIFF
--- a/EasyIK.meta
+++ b/EasyIK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8c7213e4522aa15449db6ad45ae93364
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EasyIK/Assets.meta
+++ b/EasyIK/Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db9c6aa398f3f2a4eae6c64f4e0ec57f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EasyIK/Assets/Scripts.meta
+++ b/EasyIK/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec37e5d6f6bfc674ca2686f63a072197
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EasyIK/Assets/Scripts/EasyIK.cs
+++ b/EasyIK/Assets/Scripts/EasyIK.cs
@@ -72,11 +72,7 @@ public class EasyIK : MonoBehaviour
         }
     }
 
-    void Start()
-    {
-
-    }
-
+ 
     void PoleConstraint()
     {
         if (poleTarget != null && numberOfJoints < 4)
@@ -191,7 +187,7 @@ public class EasyIK : MonoBehaviour
         jointTransforms.Last().rotation = ikTarget.rotation * offset;
     }
 
-    void Update()
+    public void OnUpdate()
     {
         SolveIK();
     }

--- a/EasyIK/Assets/Scripts/EasyIK.cs
+++ b/EasyIK/Assets/Scripts/EasyIK.cs
@@ -6,7 +6,17 @@ using System.Linq;
 
 public class EasyIK : MonoBehaviour
 {
+
+    enum UpdateMode
+    {
+        Update,
+        LateUpdate,
+        FixedUpdate,
+        ManualUpdate
+    }
+
     [Header("IK properties")]
+    [SerializeField] UpdateMode m_updateMode;
     public int numberOfJoints = 2;
     public Transform ikTarget;
     public int iterations = 10;
@@ -72,7 +82,7 @@ public class EasyIK : MonoBehaviour
         }
     }
 
- 
+
     void PoleConstraint()
     {
         if (poleTarget != null && numberOfJoints < 4)
@@ -83,7 +93,7 @@ public class EasyIK : MonoBehaviour
             // Get the direction from the root joint to the pole target and mid joint
             Vector3 poleDirection = (poleTarget.position - jointPositions[0]).normalized;
             Vector3 boneDirection = (jointPositions[1] - jointPositions[0]).normalized;
-            
+
             // Ortho-normalize the vectors
             Vector3.OrthoNormalize(ref limbAxis, ref poleDirection);
             Vector3.OrthoNormalize(ref limbAxis, ref boneDirection);
@@ -187,6 +197,23 @@ public class EasyIK : MonoBehaviour
         jointTransforms.Last().rotation = ikTarget.rotation * offset;
     }
 
+
+    void Update()
+    {
+        if (m_updateMode != UpdateMode.Update) return;
+        OnUpdate();
+    }
+    void LateUpdate()
+    {
+        if (m_updateMode != UpdateMode.LateUpdate) return;
+        OnUpdate();
+
+    }
+    void FixedUpdate()
+    {
+        if (m_updateMode != UpdateMode.FixedUpdate) return;
+        OnUpdate();
+    }
     public void OnUpdate()
     {
         SolveIK();
@@ -194,9 +221,9 @@ public class EasyIK : MonoBehaviour
 
     // Visual debugging
     void OnDrawGizmos()
-    {   
+    {
         if (debugJoints == true)
-        {   
+        {
             var current = transform;
             var child = transform.GetChild(0);
 
@@ -219,7 +246,7 @@ public class EasyIK : MonoBehaviour
         }
 
         if (localRotationAxis == true)
-        {    
+        {
             var current = transform;
             for (int i = 0; i < numberOfJoints; i += 1)
             {
@@ -240,13 +267,13 @@ public class EasyIK : MonoBehaviour
         var end = mid.GetChild(0);
 
         if (poleRotationAxis == true && poleTarget != null && numberOfJoints < 4)
-        {    
+        {
             Handles.color = Color.white;
             Handles.DrawLine(start.position, end.position);
         }
 
         if (poleDirection == true && poleTarget != null && numberOfJoints < 4)
-        {    
+        {
             Handles.color = Color.grey;
             Handles.DrawLine(start.position, poleTarget.position);
             Handles.DrawLine(end.position, poleTarget.position);
@@ -258,7 +285,7 @@ public class EasyIK : MonoBehaviour
     {
         Handles.color = Handles.xAxisColor;
         Handles.ArrowHandleCap(0, debugJoint.position, debugJoint.rotation * Quaternion.LookRotation(Vector3.right), gizmoSize, EventType.Repaint);
-                
+
         Handles.color = Handles.yAxisColor;
         Handles.ArrowHandleCap(0, debugJoint.position, debugJoint.rotation * Quaternion.LookRotation(Vector3.up), gizmoSize, EventType.Repaint);
 
@@ -266,8 +293,8 @@ public class EasyIK : MonoBehaviour
         Handles.ArrowHandleCap(0, debugJoint.position, debugJoint.rotation * Quaternion.LookRotation(Vector3.forward), gizmoSize, EventType.Repaint);
     }
 
-     public static void DrawWireCapsule(Vector3 _pos, Quaternion _rot, float _radius, float _height, Color _color = default(Color))
-     {
+    public static void DrawWireCapsule(Vector3 _pos, Quaternion _rot, float _radius, float _height, Color _color = default(Color))
+    {
         Handles.color = _color;
         Matrix4x4 angleMatrix = Matrix4x4.TRS(_pos, _rot, Handles.matrix.lossyScale);
         using (new Handles.DrawingScope(angleMatrix))
@@ -286,6 +313,6 @@ public class EasyIK : MonoBehaviour
 
             Handles.DrawWireDisc(Vector3.up * pointOffset, Vector3.up, _radius);
             Handles.DrawWireDisc(Vector3.down * pointOffset, Vector3.up, _radius);
-         }
-     }
+        }
+    }
 }

--- a/EasyIK/Assets/Scripts/EasyIK.cs
+++ b/EasyIK/Assets/Scripts/EasyIK.cs
@@ -31,7 +31,7 @@ public class EasyIK : MonoBehaviour
     public Transform ikTarget;
     public int iterations = 10;
     public float tolerance = 0.05f;
-    [SerializeField, Tooltip("WARNING: Enabling this will force rotation of the last bone to match the ik target if UpdateInEditor is enabled")] bool m_useRotationOffsetForLastJointFromIKTarget;
+    [SerializeField, Tooltip("WARNING: Disabling this will force rotation of the last bone to match the ik target if UpdateInEditor is enabled")] bool m_useRotationOffsetForLastJointFromIKTarget;
     [SerializeField] private Transform[] jointTransforms;
     private Vector3 startPosition;
     private Vector3[] jointPositions;

--- a/EasyIK/Assets/Scripts/EasyIK.cs.meta
+++ b/EasyIK/Assets/Scripts/EasyIK.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b1f3d14503ae6c343a4377931a495b0e

--- a/EasyIK/Assets/Scripts/Editor.meta
+++ b/EasyIK/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5db10a5d90dbed43baec3fe1780e690
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9faff07b7ec125a48add3f45d3ba689e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6fb4149263c7bb34492f02663ccce018
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. Users can now choose update mode: Update, Late, Fixed or Manual so that they can control when the solver runs (such as for doing some pre and post processing to the ik target's position) 

2. Update in editor: Solver can now initialize and run in editor if the option is enabled by the user

3. Assign joints in inspector: Users can optionally assign joints manually. This is essential for situations where your hierarchy differs from what EasyIK expects or your joint has multiple children besides the next joint in the chain. 

4. Last joint rotation error: Previously, if the rotation of the last joint did not match the rotation of the ik target, the offset would be incorrect. This is now fixed.

5. Optional last joint offset: By default, the last joint will now inherit the rotation of the ik target with an option to let it maintain its offset.

6. Added preprocessor directives to strip editor code from build
